### PR TITLE
Refine img style of podcasting-guide

### DIFF
--- a/src/app/layout.css
+++ b/src/app/layout.css
@@ -6,14 +6,18 @@
 
 .section {
   margin-bottom: 4rem;
+}
 
-  a {
-    border-bottom: 1px dotted var(--black-secondary);
-  }
+.section  a {
+  border-bottom: 1px dotted var(--black-secondary);
+}
 
-  p {
-    margin-bottom: 1.2rem;
-  }
+.section  p {
+  margin-bottom: 1.2rem;
+}
+
+.section img {
+  border-radius: var(--border-radius);
 }
 
 .title {
@@ -43,12 +47,5 @@
 @media screen and (max-width: 768px) {
   .main {
     width: 32rem;
-  }
-
-  section {
-    img {
-      width: 100%;
-      height: auto;
-    }
   }
 }

--- a/src/app/podcasting-guide/page.mdx
+++ b/src/app/podcasting-guide/page.mdx
@@ -1,5 +1,3 @@
-import imageOverview from '../../../public/podcasting-guide/overview.jpg'
-
 export async function generateMetadata(_) {
   const title = '収録・編集環境';
   const description = '2024年1月時点でのdining.fmのマイクやオーディオインターフェースなどの収録環境や、DAWやプラグインなど編集環境についてのまとめです。';

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -15,7 +15,12 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       <Image
         width={600}
         height={400}
-        priority={true}
+        priority={false}
+        sizes="100vw"
+        style={{
+          width: '100%',
+          height: 'auto',
+        }}
         {...(props as ImageProps)}
       />
     ),


### PR DESCRIPTION
Fix an img-broken issue on smartphone.

<img src=https://github.com/katsuma/dining.fm/assets/22689/c00d1f2e-e23c-4fe2-b8d8-eec051783cff width=360 />
