### PR TITLE
Use Spotify Player at each episode page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mdx-js/loader": "^3.0.0",
         "@mdx-js/react": "^3.0.0",
         "@next/mdx": "^14.0.4",
+        "@spotify/web-api-ts-sdk": "^1.2.0",
         "@types/mdx": "^2.0.10",
         "@types/node": "20.1.5",
         "@types/react": "18.2.6",
@@ -502,6 +503,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
+    },
+    "node_modules/@spotify/web-api-ts-sdk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@spotify/web-api-ts-sdk/-/web-api-ts-sdk-1.2.0.tgz",
+      "integrity": "sha512-JUaebva3Ohwo5I5tuTqyW/FKGOMbb40YevJMySAOINRxP7qQ/AMjBzfJx0zeO6yS+wAPfQSoGNsZaUggHw8vsA=="
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.2",
@@ -6470,6 +6476,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
+    },
+    "@spotify/web-api-ts-sdk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@spotify/web-api-ts-sdk/-/web-api-ts-sdk-1.2.0.tgz",
+      "integrity": "sha512-JUaebva3Ohwo5I5tuTqyW/FKGOMbb40YevJMySAOINRxP7qQ/AMjBzfJx0zeO6yS+wAPfQSoGNsZaUggHw8vsA=="
     },
     "@swc/helpers": {
       "version": "0.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "next": "^14.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-spotify-embed": "^2.0.3",
         "sanitize-html": "^2.11.0",
         "striptags": "^3.2.0",
         "typescript": "5.1.6",
@@ -4966,6 +4967,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-spotify-embed": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-spotify-embed/-/react-spotify-embed-2.0.3.tgz",
+      "integrity": "sha512-buiiaaPrGTyOlciJFJiHz1o2a4iSJMuH9ewi2KaIjVGcedz6szM8plz7Y6HtcDxApxCv2Rwx38xS1z8Zs3M/ZA==",
+      "dependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -9615,6 +9628,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-spotify-embed": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-spotify-embed/-/react-spotify-embed-2.0.3.tgz",
+      "integrity": "sha512-buiiaaPrGTyOlciJFJiHz1o2a4iSJMuH9ewi2KaIjVGcedz6szM8plz7Y6HtcDxApxCv2Rwx38xS1z8Zs3M/ZA==",
+      "requires": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
     },
     "readable-stream": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "next": "^14.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-spotify-embed": "^2.0.3",
     "sanitize-html": "^2.11.0",
     "striptags": "^3.2.0",
     "typescript": "5.1.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@mdx-js/loader": "^3.0.0",
     "@mdx-js/react": "^3.0.0",
     "@next/mdx": "^14.0.4",
+    "@spotify/web-api-ts-sdk": "^1.2.0",
     "@types/mdx": "^2.0.10",
     "@types/node": "20.1.5",
     "@types/react": "18.2.6",

--- a/src/app/episodes/[guid]/Player.tsx
+++ b/src/app/episodes/[guid]/Player.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from 'next/link';
+import Image from 'next/image';
+
+import sanitizeHtml from 'sanitize-html';
+import { Spotify } from 'react-spotify-embed';
+
+import styles from '@/app/episodes/[guid]/page.module.css'
+import { PublishedDate } from '@/utils/PublishedDate';
+
+type Props = {
+  title: string,
+  image: string,
+  description: string,
+  pubDate: string,
+  spotifyEpisodeId: string,
+}
+
+export function Player({ title, image, description, pubDate, spotifyEpisodeId }: Props) {
+  return (
+    <>
+      <section className='section'>
+        <h2 className='title'>{title}</h2>
+
+        <div className={styles['cover-image']}>
+          <Image
+            src={image}
+            alt={title}
+            width={600}
+            height={600}
+            sizes="100vw"
+            style={{
+              width: '100%',
+              height: 'auto',
+            }}
+            priority={true}
+          />
+        </div>
+
+        <Spotify link={`https://open.spotify.com/episode/` + spotifyEpisodeId} wide={true} />
+
+        <div className={styles.description} dangerouslySetInnerHTML={{__html: sanitizeHtml(description)}} />
+
+        <p className={styles.publishedon}>公開: {PublishedDate.parse(pubDate)}</p>
+      </section>
+
+      <section>
+        <p className='link-more'>
+          <Link href={'/episodes/page/1'}>エピソード一覧</Link>
+        </p>
+      </section>
+    </>
+  );
+}
+

--- a/src/app/episodes/[guid]/page.module.css
+++ b/src/app/episodes/[guid]/page.module.css
@@ -1,3 +1,6 @@
+.cover-image {
+  margin-bottom: 1rem;
+}
 .cover-image img {
   border-radius: var(--border-radius);
 }

--- a/src/app/episodes/[guid]/page.tsx
+++ b/src/app/episodes/[guid]/page.tsx
@@ -1,15 +1,12 @@
 import { notFound } from 'next/navigation'
-import Image from "next/image";
-import Link from 'next/link';
 import { Metadata, ResolvingMetadata } from 'next'
+import { kv } from "@vercel/kv";
 
 import '../../layout.css'
-import styles from './page.module.css'
 import { FeedLoader } from '../../../utils/FeedLoader';
 import { Episode } from '../../../components/types/Episode';
-import { PublishedDate } from '../../../utils/PublishedDate';
+import { Player } from './Player';
 
-import sanitizeHtml from 'sanitize-html';
 import striptags from 'striptags';
 import { parseStringPromise } from 'xml2js';
 import React from 'react';
@@ -21,6 +18,10 @@ type Props = {
 async function fetchEpisode({ params }: Props) {
   const episodes = await FeedLoader.loadAsEpisodes() as Episode[];
   return episodes.find((episode) => episode.guid === params.guid) as Episode;
+}
+
+async function fetchSpotifyId(idKey: string) {
+  return kv.get(idKey)
 }
 
 export async function generateMetadata({ params }: Props, parent: ResolvingMetadata): Promise<Metadata> {
@@ -51,35 +52,15 @@ export default async function EpisodeDetail({ params }: { params: { guid: string
     notFound()
   }
 
+  const spotifyEpisodeId = await fetchSpotifyId(episode.guid);
+
   return (
-    <>
-      <section className='section'>
-        <h2 className='title'>{episode.title}</h2>
-        <div className={styles['cover-image']}>
-          <Image
-            src={episode.image}
-            alt={episode.title}
-            width={600}
-            height={600}
-            sizes="100vw"
-            style={{
-              width: '100%',
-              height: 'auto',
-            }}
-            priority={false}
-          />
-        </div>
-        <audio className={styles.audio} controls={true} src={episode.url}>
-          <a href={episode.url}>Download audio</a>
-        </audio>
-        <div className={styles.description} dangerouslySetInnerHTML={{__html: sanitizeHtml(episode.description)}} />
-        <p className={styles.publishedon}>公開: {PublishedDate.parse(episode.pubDate)}</p>
-      </section>
-      <section>
-        <p className='link-more'>
-          <Link href={'/episodes/page/1'}>エピソード一覧</Link>
-        </p>
-      </section>
-    </>
+    <Player
+      title={episode.title}
+      image={episode.image}
+      description={episode.description}
+      pubDate={episode.pubDate}
+      spotifyEpisodeId={spotifyEpisodeId}
+    />
   )
 }

--- a/src/app/episodes/[guid]/page.tsx
+++ b/src/app/episodes/[guid]/page.tsx
@@ -21,7 +21,7 @@ async function fetchEpisode({ params }: Props) {
 }
 
 async function fetchSpotifyId(idKey: string) {
-  return kv.get(idKey)
+  return kv.get(idKey);
 }
 
 export async function generateMetadata({ params }: Props, parent: ResolvingMetadata): Promise<Metadata> {
@@ -60,7 +60,7 @@ export default async function EpisodeDetail({ params }: { params: { guid: string
       image={episode.image}
       description={episode.description}
       pubDate={episode.pubDate}
-      spotifyEpisodeId={spotifyEpisodeId}
+      spotifyEpisodeId={String(spotifyEpisodeId)}
     />
   )
 }


### PR DESCRIPTION
This PR enables Spotify Player instead of audio tag.
Spotify episode ID is given by Vercel KV introduced by https://github.com/katsuma/dining.fm/pull/39.

<img width="405" alt="image" src="https://github.com/katsuma/dining.fm/assets/22689/ff377e07-f9e4-4842-857d-de1e033d4602">
