### PR TITLE
Revert "Specify summary_large_image for Twitter OGP"

### DIFF
--- a/src/app/episodes/[guid]/page.tsx
+++ b/src/app/episodes/[guid]/page.tsx
@@ -43,7 +43,6 @@ export async function generateMetadata({ params }: Props, parent: ResolvingMetad
     twitter: {
       title: episode.title,
       description: description,
-      card: 'summary_large_image',
     }
   }
 }


### PR DESCRIPTION
Reverts katsuma/dining.fm#48

summary_large_image is not good at current Twitter.