### PR TITLE
Adds scripts to fetch episodes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'http://rubygems.org'
+
+gem "base64"
+gem "ferrum"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,28 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.2.0)
+    concurrent-ruby (1.2.3)
+    ferrum (0.15)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
+    public_suffix (5.0.5)
+    webrick (1.8.1)
+    websocket-driver (0.7.6)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  base64
+  ferrum
+
+BUNDLED WITH
+   2.5.3

--- a/scripts/lib/episode.rb
+++ b/scripts/lib/episode.rb
@@ -1,0 +1,21 @@
+require 'json'
+
+class Episode
+  attr_reader :service
+  attr_reader :title
+  attr_reader :id
+
+  def initialize(service:, id:, title:)
+    @service = service
+    @id = id
+    @title = title
+  end
+
+  def to_json
+    {
+      service: service,
+      id: id,
+      title: title,
+    }.to_json
+  end
+end

--- a/scripts/lib/fetcher.rb
+++ b/scripts/lib/fetcher.rb
@@ -1,0 +1,25 @@
+require "ferrum"
+require_relative "episode"
+
+class Fetcher
+  attr_reader :service
+
+  def initialize(service)
+    @service = service
+  end
+
+  def fetch
+    browser = Ferrum::Browser.new
+    browser.goto(service.url)
+    episodes = browser.css(service.episode_selector).map do |episode_element|
+      Episode.new(
+        service: service.name,
+        id: service.id_from_element(episode_element),
+        title: service.title_from_element(episode_element),
+      )
+    end
+    episodes
+  ensure
+    browser.quit
+  end
+end

--- a/scripts/lib/service/apple.rb
+++ b/scripts/lib/service/apple.rb
@@ -1,0 +1,25 @@
+require "addressable/uri"
+require_relative "base"
+
+class Service::Apple < Service::Base
+  def self.name
+    "apple"
+  end
+
+  def self.url
+    "https://podcasts.apple.com/us/podcast/id1668849655"
+  end
+
+  def self.episode_selector
+    "ol.tracks li a"
+  end
+
+  def self.id_from_element(element)
+    link = element.attribute("href")
+    Addressable::URI.parse(link).query_values["i"]
+  end
+
+  def self.title_from_element(element)
+    element.text.strip
+  end
+end

--- a/scripts/lib/service/base.rb
+++ b/scripts/lib/service/base.rb
@@ -1,0 +1,23 @@
+module Service
+  class Base
+    def self.name
+      raise NotImplementedError
+    end
+
+    def self.url
+      raise NotImplementedError
+    end
+
+    def self.episode_selector
+      raise NotImplementedError
+    end
+
+    def self.id_from_element(element)
+      raise NotImplementedError
+    end
+
+    def self.title_from_element(element)
+      raise NotImplementedError
+    end
+  end
+end

--- a/scripts/lib/service/spotify.rb
+++ b/scripts/lib/service/spotify.rb
@@ -1,0 +1,23 @@
+require_relative "base"
+
+class Service::Spotify < Service::Base
+  def self.name
+    "spotify"
+  end
+
+  def self.url
+    "https://open.spotify.com/show/3wSB2J20uqON5nPhCmMia5"
+  end
+
+  def self.episode_selector
+    "div[data-testid='infinite-scroll-list'] a[href^='/episode']"
+  end
+
+  def self.id_from_element(element)
+    element.attribute("href").split("/").last
+  end
+
+  def self.title_from_element(element)
+    element.css("div")[0]&.text
+  end
+end

--- a/scripts/set-episode-builder
+++ b/scripts/set-episode-builder
@@ -1,0 +1,37 @@
+#! /usr/bin/env ruby
+
+#
+# This script fetches the episode ID from the publishing service and prints the command to set the episode.
+#
+# Usage:
+# service_name={publishing_service_name} episode_number={target_episode_number} set-episode-builder
+#   publishing_service_name: apple, spotify
+#   target_episode_number: 123, 124, 125, ...
+#
+# Example:
+# service_name=apple episode_number=123 set-episode-builder
+#
+# Output:
+# npm run set-episode --ep=123 --service=apple --id=1234567890
+#
+# You can copy the output and run it in the terminal to set the episode.
+#
+# Example:
+# service_name=apple episode_number=123 set-episode-builder | sh
+
+require_relative 'lib/fetcher'
+require_relative 'lib/service/apple'
+require_relative 'lib/service/spotify'
+
+service_name = ENV.fetch('service_name')
+service = case service_name
+          when 'apple' then Service::Apple
+          when 'spotify' then Service::Spotify
+          else raise "Unknown service: #{service_name}"
+          end
+episode_number = ENV.fetch('episode_number')
+
+fetcher = Fetcher.new(service)
+episode = fetcher.fetch.find { |episode| episode.title.start_with?(episode_number) }
+
+puts "npm run set-episode --ep=#{episode_number} --service=#{service_name} --id=#{episode.id}"


### PR DESCRIPTION
This pull request adds a Ruby script named set-episode-builder. 
The output of this script can be used as an execution command for existing npm-scripts. For example:

```
service_name=apple episode_number=123 set-episode-builder | sh
```

This allows for the automation of the process of saving episode IDs in storage across various platforms.