### PR TITLE
Cache control

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,19 +2,6 @@ const withMDX = require('@next/mdx')()
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  async headers() {
-    return [
-      {
-        source: '/',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 's-maxage=1, stale-while-revalidate=59',
-          },
-        ],
-      },
-    ];
-  },
   images: {
     remotePatterns: [
       {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next({
+    request: {
+      headers: new Headers(request.headers),
+    },
+  });
+
+  response.headers.set('cache-control', 'public, max-age=600, s-maxage=600, stale-while-revalidate=60');
+  return response;
+}


### PR DESCRIPTION
We cannot set  Cache-Control headers in next.config.js.
https://nextjs.org/docs/app/api-reference/next-config-js/headers#cache-control

So we revert previous PR. [b80b51e](https://github.com/katsuma/dining.fm/pull/73/commits/b80b51eb35f4300e4b15376f0b9b2c7007de39fc)
https://github.com/katsuma/dining.fm/pull/69

And we try using middleware. [4d31200](https://github.com/katsuma/dining.fm/pull/73/commits/4d312006df71fabee140864ae1cd9c4fd0d7eefa)
https://nextjs.org/docs/app/building-your-application/routing/middleware#setting-headers