### PR TITLE
Add /feed route redirecting to RSS feed and autodiscovery meta tag

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -31,6 +31,12 @@ export const links: Route.LinksFunction = () => [
     rel: "stylesheet",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Zen+Maru+Gothic:wght@400;500;700;900&display=swap",
   },
+  {
+    rel: "alternate",
+    type: "application/rss+xml",
+    title: "dining.fm",
+    href: "/feed",
+  },
 ];
 export function Layout({ children }: { children: React.ReactNode }) {
   useEffect(() => {

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -9,6 +9,7 @@ export default [
   route("sitemap.xml", "routes/sitemap.tsx"),
   route("letter", "routes/letter.tsx"),
   route("store", "routes/store.tsx"),
+  route("feed", "routes/feed.tsx"),
   layout("layout.tsx", [
     index("routes/home.tsx"),
     route("episodes/page/:page", "routes/episodes/page.tsx"),

--- a/app/routes/feed.tsx
+++ b/app/routes/feed.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "react-router";
+import type { Route } from "./+types/feed";
+
+export function loader(_args: Route.LoaderArgs) {
+  return redirect("https://anchor.fm/s/d89790f4/podcast/rss");
+}


### PR DESCRIPTION
## Summary

- Add `app/routes/feed.tsx` that redirects `/feed` to https://anchor.fm/s/d89790f4/podcast/rss
- Register the route in `app/routes.ts`
- Add RSS autodiscovery `<link rel="alternate">` tag in `app/root.tsx` so browsers and podcast apps can detect the feed automatically

## Test plan

- [ ] Visit `/feed` and confirm it redirects to the RSS feed URL
- [ ] Check page source and confirm `<link rel="alternate" type="application/rss+xml">` is present in `<head>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)