### PR TITLE
Change body font to M PLUS 1p, keep Zen Maru Gothic for headings

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -1,14 +1,17 @@
 @import "tailwindcss";
 @import "@fontsource/m-plus-rounded-1c/400.css";
 @import "@fontsource/m-plus-rounded-1c/800.css";
+@import "@fontsource/m-plus-1p/400.css";
+@import "@fontsource/m-plus-1p/700.css";
 @import "tw-animate-css";
 
 :root {
   --font-*: initial;
   --font-sans:
-    "Zen Maru Gothic", "M PLUS Rounded 1c", "Inter", ui-sans-serif, system-ui,
+    "M PLUS 1p", "Inter", ui-sans-serif, system-ui,
     sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji";
+  --font-heading-value: "Zen Maru Gothic", "M PLUS Rounded 1c", sans-serif;
   --font-numeric-value: "M PLUS Rounded 1c", sans-serif;
   --black-primary: #373737;
   --black-secondary: #676767;
@@ -33,6 +36,7 @@ body {
 }
 
 @theme inline {
+  --font-heading: var(--font-heading-value);
   --font-numeric: var(--font-numeric-value);
   --color-orange: var(--orange);
   --color-green: var(--green);

--- a/app/components/EpisodeCard.tsx
+++ b/app/components/EpisodeCard.tsx
@@ -23,7 +23,7 @@ export const EpisodeCard = ({ episode }: { episode: Episode }) => (
         </div>
       </div>
       <div className="flex flex-col justify-between min-w-0">
-        <p className="text-[16px] font-bold text-black-primary tracking-[-0.45px] leading-normal mb-1">
+        <p className="font-heading text-[16px] font-bold text-black-primary tracking-[-0.45px] leading-normal mb-1">
           <span className="font-numeric text-[15px] font-bold">
             {episode.id}.
           </span>{" "}

--- a/app/components/Heading.tsx
+++ b/app/components/Heading.tsx
@@ -8,7 +8,7 @@ export const Heading = ({ title, dotClassName = "bg-green" }: Props) => (
     <span
       className={`inline-block size-[10px] rounded-full shrink-0 border-2 border-black ${dotClassName}`}
     />
-    <h2 className="text-[18px] font-bold tracking-[-0.54px] text-black">
+    <h2 className="font-heading text-[18px] font-bold tracking-[-0.54px] text-black">
       {title}
     </h2>
   </div>

--- a/app/components/mdx-components.tsx
+++ b/app/components/mdx-components.tsx
@@ -9,11 +9,11 @@ const Anchor = forwardRef<HTMLAnchorElement, ComponentProps<"a">>(
 Anchor.displayName = "Anchor";
 
 function Heading2(props: React.ComponentProps<"h1">) {
-  return <h2 {...props} className="title" />;
+  return <h2 {...props} className="font-heading title" />;
 }
 
 function Heading3(props: React.ComponentProps<"h1">) {
-  return <h3 {...props} className="mb-2 text-[1.4rem] font-semibold" />;
+  return <h3 {...props} className="font-heading mb-2 text-[1.4rem] font-semibold" />;
 }
 
 function P(props: React.ComponentProps<"p">) {

--- a/app/routes/episodes/show.tsx
+++ b/app/routes/episodes/show.tsx
@@ -101,7 +101,7 @@ function EpisodeDetail() {
   return (
     <div className="container">
       <section className="mb-8">
-        <h2 className="text-[22px] font-bold tracking-[-0.66px] text-black-primary leading-snug mb-2">
+        <h2 className="font-heading text-[22px] font-bold tracking-[-0.66px] text-black-primary leading-snug mb-2">
           <span className="font-numeric">{episode.id}.</span> {episode.title}
         </h2>
         <div className="h-[5px] rounded-full bg-orange border border-black mb-4" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "dining.fm",
       "hasInstallScript": true,
       "dependencies": {
+        "@fontsource/m-plus-1p": "^5.2.9",
         "@fontsource/m-plus-rounded-1c": "^5.2.8",
         "@mdx-js/react": "^3.1.0",
         "@mdx-js/rollup": "^3.1.0",
@@ -1179,6 +1180,15 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@fontsource/m-plus-1p": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/m-plus-1p/-/m-plus-1p-5.2.9.tgz",
+      "integrity": "sha512-SdstxK+xoUHmSkbmYTnPRWZWEfuQax6ZR0XbFhU82z5GA4X/YRE+VX54q0aDRJ5btej/fvFtww3qHFvp9A06GQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@fontsource/m-plus-rounded-1c": {
       "version": "5.2.10",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@fontsource/m-plus-1p": "^5.2.9",
     "@fontsource/m-plus-rounded-1c": "^5.2.8",
     "@mdx-js/react": "^3.1.0",
     "@mdx-js/rollup": "^3.1.0",


### PR DESCRIPTION
## Summary

- Install `@fontsource/m-plus-1p` and import 400/700 weights
- Change `--font-sans` to use `M PLUS 1p` as the body font
- Define `--font-heading` with `Zen Maru Gothic` for headings
- Apply `font-heading` to `Heading` component, MDX h2/h3, episode card titles, and episode detail page title

## Test plan

- [ ] Body text renders in M PLUS 1p
- [ ] Section headings (`Heading` component) render in Zen Maru Gothic
- [ ] Episode titles on top page and list render in Zen Maru Gothic
- [ ] Episode detail page title renders in Zen Maru Gothic

🤖 Generated with [Claude Code](https://claude.com/claude-code)