### PR TITLE
Fix episode description spacing: hide empty paragraphs and remove p+ul margin

### DIFF
--- a/app/routes/episodes/show.tsx
+++ b/app/routes/episodes/show.tsx
@@ -155,7 +155,7 @@ function EpisodeDescription({
 }) {
   return (
     <div
-      className={`${proseStyles} break-all [&_p]:mb-4 [&_p:empty]:hidden [&_p:has(>br:only-child)]:hidden [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:ml-3 [&_ul_li]:mb-2`}
+      className={`${proseStyles} break-all [&_p]:mb-4 [&_p:empty]:hidden [&_p:has(>br:only-child)]:hidden [&_p:has(+ul)]:mb-0 [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:ml-3 [&_ul_li]:mb-2`}
       dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
     />
   );

--- a/app/routes/episodes/show.tsx
+++ b/app/routes/episodes/show.tsx
@@ -155,7 +155,7 @@ function EpisodeDescription({
 }) {
   return (
     <div
-      className={`${proseStyles} break-all [&_p]:mb-4 [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:ml-3 [&_ul_li]:mb-2`}
+      className={`${proseStyles} break-all [&_p]:mb-4 [&_p:empty]:hidden [&_p:has(>br:only-child)]:hidden [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:ml-3 [&_ul_li]:mb-2`}
       dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
     />
   );


### PR DESCRIPTION
## Summary

- Hide empty `<p></p>` and `<p><br /></p>` elements in episode descriptions
- Remove `margin-bottom` from `<p>` when immediately followed by `<ul>`

## Test plan

- [ ] Empty paragraphs in episode descriptions are no longer visible
- [ ] No extra spacing between a paragraph and the following list

🤖 Generated with [Claude Code](https://claude.com/claude-code)