### PR TITLE
Add /sp/:id route for special MP3 episode pages

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -15,5 +15,6 @@ export default [
     route("episodes/page/:page", "routes/episodes/page.tsx"),
     route("episodes/:id", "routes/episodes/show.tsx"),
     route("podcasting-guide", "routes/podcasting-guide/show.tsx"),
+    route("sp/:id", "routes/sp/show.tsx"),
   ]),
 ] satisfies RouteConfig;

--- a/app/routes/sp/show.tsx
+++ b/app/routes/sp/show.tsx
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/show";
 
 import { Link, useLoaderData } from "react-router-dom";
-import { type Episode } from "@prisma/client";
 
 import { LabelBadge } from "@/components/LabelBadge";
 import { proseStyles, Paragraph } from "@/components/Paragraph";
@@ -10,20 +9,22 @@ import { EpisodeCard } from "@/components/EpisodeCard";
 import { Heading } from "@/components/Heading";
 import { LinkButton } from "@/components/LinkButton";
 import prisma from "@/utils/prisma";
+import type { Episode } from "@prisma/client";
 
 type SpContent = {
   title: string;
   description: string;
   mp3Url: string;
+  relatedEpisodeIds: number[];
 };
 
 const SP_CONTENT: Record<string, SpContent> = {
   pcwe2026: {
     title: "Podcast Weekend 2026 スペシャルエピソード",
     description:
-      "※このエピソードはPodcast Weekend 2026 来場者の方向けのスペシャルエピソードです。通常回では語られないkatsuma, daikokuのプロフィールや、これまでの中からおすすめエピソードを紹介します。",
-    mp3Url:
-      "https://diningfm.s3.us-east-1.amazonaws.com/public/sp/pcwe2026.mp3",
+      "※このエピソードはPodcast Weekend 2026 来場者の方向けのスペシャルエピソードです。\n通常回では語られないkatsuma, daikokuのプロフィールや、番組紹介を含む過去のエピソードの中からおすすめエピソードを紹介します。",
+    mp3Url: "/sp/pcwe2026.mp3",
+    relatedEpisodeIds: [174, 141, 145, 120, 28, 163, 173],
   },
 };
 
@@ -36,9 +37,8 @@ export async function loader({ params }: Route.LoaderArgs) {
     throw new Response(NOT_FOUND_MESSAGE, { status: 404 });
   }
 
-  const latestEpisodes = await prisma.episode.findMany({
-    orderBy: [{ id: "desc" }],
-    take: 5,
+  const episodesUnordered = await prisma.episode.findMany({
+    where: { id: { in: content.relatedEpisodeIds } },
     select: {
       id: true,
       title: true,
@@ -50,7 +50,12 @@ export async function loader({ params }: Route.LoaderArgs) {
     },
   });
 
-  return { id: params.id, content, latestEpisodes };
+  const episodeMap = new Map(episodesUnordered.map((e) => [e.id, e]));
+  const relatedEpisodes = content.relatedEpisodeIds
+    .map((id) => episodeMap.get(id))
+    .filter((e) => e !== undefined);
+
+  return { id: params.id, content, relatedEpisodes };
 }
 
 export function meta({ data }: Route.MetaArgs) {
@@ -64,6 +69,7 @@ export function meta({ data }: Route.MetaArgs) {
 
   return buildMeta([
     { title },
+    { name: "robots", content: "noindex" },
 
     { property: "og:url", content: url },
     { property: "og:title", content: title },
@@ -73,12 +79,15 @@ export function meta({ data }: Route.MetaArgs) {
     { property: "twitter:url", content: url },
     { property: "twitter:title", content: title },
     { property: "twitter:description", content: description },
-    { property: "twitter:image", content: `${defaultHost}/opengraph-image.png` },
+    {
+      property: "twitter:image",
+      content: `${defaultHost}/opengraph-image.png`,
+    },
   ]);
 }
 
 function SpShow() {
-  const { content, latestEpisodes } = useLoaderData();
+  const { content, relatedEpisodes } = useLoaderData();
 
   return (
     <div className="container">
@@ -114,14 +123,16 @@ function SpShow() {
       </section>
 
       <section className="mb-8">
-        <Heading title="最新エピソード" dotClassName="bg-orange" />
+        <Heading title="関連エピソード" dotClassName="bg-orange" />
         <div className="flex flex-col gap-3">
-          {latestEpisodes.map((episode: Episode) => (
+          {relatedEpisodes.map((episode: Episode) => (
             <EpisodeCard episode={episode} key={episode.id} />
           ))}
         </div>
         <div className="flex justify-center mt-6">
-          <LinkButton to="/episodes/page/1">すべて見る</LinkButton>
+          <LinkButton to="/episodes/page/1">
+            すべてのエピソードを見る
+          </LinkButton>
         </div>
       </section>
     </div>

--- a/app/routes/sp/show.tsx
+++ b/app/routes/sp/show.tsx
@@ -9,7 +9,6 @@ import { EpisodeCard } from "@/components/EpisodeCard";
 import { Heading } from "@/components/Heading";
 import { LinkButton } from "@/components/LinkButton";
 import prisma from "@/utils/prisma";
-import type { Episode } from "@prisma/client";
 
 type SpContent = {
   title: string;
@@ -39,15 +38,6 @@ export async function loader({ params }: Route.LoaderArgs) {
 
   const episodesUnordered = await prisma.episode.findMany({
     where: { id: { in: content.relatedEpisodeIds } },
-    select: {
-      id: true,
-      title: true,
-      description: true,
-      publishedAt: true,
-      imageUrl: true,
-      enclosureUrl: true,
-      duration: true,
-    },
   });
 
   const episodeMap = new Map(episodesUnordered.map((e) => [e.id, e]));
@@ -87,7 +77,7 @@ export function meta({ data }: Route.MetaArgs) {
 }
 
 function SpShow() {
-  const { content, relatedEpisodes } = useLoaderData();
+  const { content, relatedEpisodes } = useLoaderData<typeof loader>();
 
   return (
     <div className="container">
@@ -125,7 +115,7 @@ function SpShow() {
       <section className="mb-8">
         <Heading title="関連エピソード" dotClassName="bg-orange" />
         <div className="flex flex-col gap-3">
-          {relatedEpisodes.map((episode: Episode) => (
+          {relatedEpisodes.map((episode) => (
             <EpisodeCard episode={episode} key={episode.id} />
           ))}
         </div>

--- a/app/routes/sp/show.tsx
+++ b/app/routes/sp/show.tsx
@@ -1,0 +1,100 @@
+import type { Route } from "./+types/show";
+
+import { Link, useLoaderData } from "react-router-dom";
+
+import { LabelBadge } from "@/components/LabelBadge";
+import { proseStyles, Paragraph } from "@/components/Paragraph";
+import { defaultTitle, defaultDescription, defaultHost, buildMeta } from "@/utils/meta";
+
+type SpContent = {
+  title: string;
+  description: string;
+  mp3Url: string;
+};
+
+const SP_CONTENT: Record<string, SpContent> = {
+  pcwe2026: {
+    title: "Podcast Weekend 2026 スペシャルエピソード",
+    description:
+      "※このエピソードはPodcast Weekend 2026 来場者の方向けのスペシャルエピソードです。通常回では語られないkatsuma, daikokuのプロフィールや、これまでの中からおすすめエピソードを紹介します。",
+    mp3Url:
+      "https://diningfm.s3.us-east-1.amazonaws.com/public/sp/pcwe2026.mp3",
+  },
+};
+
+const NOT_FOUND_MESSAGE = "指定したコンテンツは見つかりませんでした";
+
+export function loader({ params }: Route.LoaderArgs) {
+  const content = SP_CONTENT[params.id];
+
+  if (!content) {
+    throw new Response(NOT_FOUND_MESSAGE, { status: 404 });
+  }
+
+  return { id: params.id, content };
+}
+
+export function meta({ data }: Route.MetaArgs) {
+  if (!data) {
+    return buildMeta([]);
+  }
+
+  const title = `${data.content.title} | ${defaultTitle}`;
+  const description = data.content.description;
+  const url = `${defaultHost}/sp/${data.id}`;
+
+  return buildMeta([
+    { title },
+
+    { property: "og:url", content: url },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+    { property: "og:image", content: `${defaultHost}/opengraph-image.png` },
+
+    { property: "twitter:url", content: url },
+    { property: "twitter:title", content: title },
+    { property: "twitter:description", content: description },
+    { property: "twitter:image", content: `${defaultHost}/opengraph-image.png` },
+  ]);
+}
+
+function SpShow() {
+  const { content } = useLoaderData();
+
+  return (
+    <div className="container">
+      <section className="mb-8">
+        <h2 className="font-heading text-[22px] font-bold tracking-[-0.66px] text-black-primary leading-snug mb-2">
+          {content.title}
+        </h2>
+        <div className="h-[5px] rounded-full bg-orange border border-black mb-4" />
+      </section>
+
+      <audio className="w-full my-8" controls src={content.mp3Url}>
+        <a href={content.mp3Url}>ダウンロード</a>
+      </audio>
+
+      <section className="relative mb-10">
+        <LabelBadge text="SP" />
+        <div className="bg-white border-2 border-black rounded-(--card-radius) shadow-(--card-shadow) p-6 pt-8">
+          <p className={`${proseStyles} whitespace-pre-wrap`}>
+            {content.description}
+          </p>
+          <hr className="border-t border-gray-300 border-dashed my-6" />
+          <Paragraph>
+            感想はX(Twitter)のハッシュタグ
+            <Link to="https://twitter.com/search?q=%23diningfm&src=typed_query&f=top">
+              #diningfm
+            </Link>{" "}
+            や<Link to="https://twitter.com/diningfm">@diningfm</Link>{" "}
+            へのリプライ、
+            <Link to="/letter">GoogleForm</Link>
+            でのお便りなどからお待ちしています📮
+          </Paragraph>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default SpShow;

--- a/app/routes/sp/show.tsx
+++ b/app/routes/sp/show.tsx
@@ -1,10 +1,15 @@
 import type { Route } from "./+types/show";
 
 import { Link, useLoaderData } from "react-router-dom";
+import { type Episode } from "@prisma/client";
 
 import { LabelBadge } from "@/components/LabelBadge";
 import { proseStyles, Paragraph } from "@/components/Paragraph";
-import { defaultTitle, defaultDescription, defaultHost, buildMeta } from "@/utils/meta";
+import { defaultTitle, defaultHost, buildMeta } from "@/utils/meta";
+import { EpisodeCard } from "@/components/EpisodeCard";
+import { Heading } from "@/components/Heading";
+import { LinkButton } from "@/components/LinkButton";
+import prisma from "@/utils/prisma";
 
 type SpContent = {
   title: string;
@@ -24,14 +29,28 @@ const SP_CONTENT: Record<string, SpContent> = {
 
 const NOT_FOUND_MESSAGE = "指定したコンテンツは見つかりませんでした";
 
-export function loader({ params }: Route.LoaderArgs) {
+export async function loader({ params }: Route.LoaderArgs) {
   const content = SP_CONTENT[params.id];
 
   if (!content) {
     throw new Response(NOT_FOUND_MESSAGE, { status: 404 });
   }
 
-  return { id: params.id, content };
+  const latestEpisodes = await prisma.episode.findMany({
+    orderBy: [{ id: "desc" }],
+    take: 5,
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      publishedAt: true,
+      imageUrl: true,
+      enclosureUrl: true,
+      duration: true,
+    },
+  });
+
+  return { id: params.id, content, latestEpisodes };
 }
 
 export function meta({ data }: Route.MetaArgs) {
@@ -59,7 +78,7 @@ export function meta({ data }: Route.MetaArgs) {
 }
 
 function SpShow() {
-  const { content } = useLoaderData();
+  const { content, latestEpisodes } = useLoaderData();
 
   return (
     <div className="container">
@@ -91,6 +110,18 @@ function SpShow() {
             <Link to="/letter">GoogleForm</Link>
             でのお便りなどからお待ちしています📮
           </Paragraph>
+        </div>
+      </section>
+
+      <section className="mb-8">
+        <Heading title="最新エピソード" dotClassName="bg-orange" />
+        <div className="flex flex-col gap-3">
+          {latestEpisodes.map((episode: Episode) => (
+            <EpisodeCard episode={episode} key={episode.id} />
+          ))}
+        </div>
+        <div className="flex justify-center mt-6">
+          <LinkButton to="/episodes/page/1">すべて見る</LinkButton>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Add new `/sp/:id` route for special episodes distributed via external links (ads, events, etc.)
- Content mapping (`SP_CONTENT`) is managed in code — no DB needed
- First entry: `/sp/pcwe2026` for Podcast Weekend 2026 attendees
- Layout follows existing `/episodes/:id` style (header/footer included, HTML5 audio player)
- Each SP content defines `relatedEpisodeIds`; related episodes are fetched and displayed in the specified order
- Section title: 「関連エピソード」with a link to the full episode list
- `noindex` meta tag applied to all `/sp/*` pages (not intended for search indexing)
- No internal links to `/sp/*` pages; GA tracks pageviews automatically

## Test plan
- [ ] Access `/sp/pcwe2026` and confirm title, audio player, and description render correctly
- [ ] Confirm related episodes are displayed in the order: 174, 141, 145, 120, 28, 163, 173
- [ ] Access `/sp/unknown` and confirm 404 response
- [ ] Confirm header/footer are displayed
- [ ] Confirm `<meta name="robots" content="noindex">` is present in the page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)