### PR TITLE
Use React Router v7 href() for type-safe internal links

### DIFF
--- a/app/components/EpisodeCard.tsx
+++ b/app/components/EpisodeCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, href } from "react-router";
 import { CirclePlay } from "lucide-react";
 import { type Episode } from "@prisma/client";
 import { PublishedDate } from "@/utils/PublishedDate";
@@ -13,7 +13,7 @@ type EpisodeCardEpisode = Pick<
 
 export const EpisodeCard = ({ episode }: { episode: EpisodeCardEpisode }) => (
   <Link
-    to={`/episodes/${episode.id}`}
+    to={href("/episodes/:id", { id: String(episode.id) })}
     className="block border-b-0 no-underline"
   >
     <div className="group flex items-start gap-4 bg-white border-2 border-black rounded-(--card-radius) p-4 transition-all duration-200 hover:bg-episode-hover-bg hover:shadow-(--card-shadow) hover:mt-[-5px] hover:mb-[5px]">

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, href } from "react-router";
 
 const Header = () => {
   return (
@@ -11,7 +11,7 @@ const Header = () => {
     >
       <div className="flex justify-center py-8">
         <h1>
-          <Link to={"/"}>
+          <Link to={href("/")}>
             <img src="/logo.svg" alt="dining.fm" width={176} height={60} />
           </Link>
         </h1>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,15 +1,16 @@
 import React, { useEffect } from "react";
 import ReactGA from "react-ga4";
-import { Outlet } from "react-router-dom";
 import { MDXProvider } from "@mdx-js/react";
 import { components } from "@/components/mdx-components";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 
 import {
+  href,
   isRouteErrorResponse,
   Links,
   Meta,
+  Outlet,
   Scripts,
   ScrollRestoration,
 } from "react-router";
@@ -91,7 +92,7 @@ function ErrorContent({
         )}
       </section>
       <section className="text-center my-16">
-        <LinkButton to="/">トップページへ戻る</LinkButton>
+        <LinkButton to={href("/")}>トップページへ戻る</LinkButton>
       </section>
     </div>
   );

--- a/app/routes/episodes/page.tsx
+++ b/app/routes/episodes/page.tsx
@@ -1,6 +1,6 @@
 // provides type safety/inference
 import type { Route } from "./+types/page";
-import { useLoaderData } from "react-router-dom";
+import { useLoaderData, href } from "react-router";
 import { type Episode } from "@prisma/client";
 
 import prisma from "@/utils/prisma";
@@ -78,12 +78,12 @@ function EpisodesPage() {
       </section>
       <section className="flex justify-center space-x-4 mt-6 mb-10">
         {currentPage - 1 > 0 && (
-          <LinkButton to={`/episodes/page/${currentPage - 1}`}>
+          <LinkButton to={href("/episodes/page/:page", { page: String(currentPage - 1) })}>
             « 前へ
           </LinkButton>
         )}
         {currentPage + 1 <= maxPage && (
-          <LinkButton to={`/episodes/page/${currentPage + 1}`}>
+          <LinkButton to={href("/episodes/page/:page", { page: String(currentPage + 1) })}>
             次へ »
           </LinkButton>
         )}

--- a/app/routes/episodes/show.tsx
+++ b/app/routes/episodes/show.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/show";
 
-import { Link, useLoaderData } from "react-router-dom";
+import { Link, href, useLoaderData } from "react-router";
 import { IoCalendarOutline } from "react-icons/io5";
 import { FaRegClock } from "react-icons/fa";
 import sanitizeHtml from "sanitize-html";
@@ -200,7 +200,7 @@ function EpisodeDetail() {
             </Link>{" "}
             や<Link to="https://twitter.com/diningfm">@diningfm</Link>{" "}
             へのリプライ、
-            <Link to="/letter">GoogleForm</Link>
+            <Link to={href("/letter")}>GoogleForm</Link>
             でのお便りなどからお待ちしています📮
           </Paragraph>
         </div>
@@ -218,7 +218,7 @@ function EpisodeDetail() {
       )}
 
       <section className="flex justify-center my-10">
-        <LinkButton to={"/episodes/page/1"}>一覧へ戻る</LinkButton>
+        <LinkButton to={href("/episodes/page/:page", { page: "1" })}>一覧へ戻る</LinkButton>
       </section>
 
       <script

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,4 +1,4 @@
-import { Link, type LoaderFunction, useLoaderData } from "react-router-dom";
+import { Link, href, type LoaderFunction, useLoaderData } from "react-router";
 import { type Episode } from "@prisma/client";
 import type { Route } from "./+types/home";
 
@@ -63,13 +63,13 @@ const Home = () => {
           ))}
         </div>
         <div className="flex justify-center mt-6">
-          <LinkButton to="/episodes/page/1">すべて見る</LinkButton>
+          <LinkButton to={href("/episodes/page/:page", { page: "1" })}>すべて見る</LinkButton>
         </div>
       </section>
 
       <section className="mb-8 text-center">
         <div className="grid grid-cols-2 gap-2 md:flex md:justify-center md:space-x-4 md:mx-auto">
-          <Link to="/spotify" target="_blank" rel="noopener noreferrer">
+          <Link to={href("/spotify")} target="_blank" rel="noopener noreferrer">
             <img
               src={"/listen-on/spotify.svg"}
               alt={"Listen on Spotify"}
@@ -78,7 +78,7 @@ const Home = () => {
             />
           </Link>
 
-          <Link to="/applepodcasts" target="_blank" rel="noopener noreferrer">
+          <Link to={href("/applepodcasts")} target="_blank" rel="noopener noreferrer">
             <img
               src={"/listen-on/apple.svg"}
               alt={"Listen on Apple Podcasts"}
@@ -87,7 +87,7 @@ const Home = () => {
             />
           </Link>
 
-          <Link to="/youtube" target="_blank" rel="noopener noreferrer">
+          <Link to={href("/youtube")} target="_blank" rel="noopener noreferrer">
             <img
               src={"/listen-on/youtube.svg"}
               alt={"Listen on YouTube"}
@@ -104,7 +104,7 @@ const Home = () => {
           <ArticleCard
             thumbnailUrl="/podcasting-guide/mic.jpg"
             title="収録・編集環境"
-            linkUrl="/podcasting-guide"
+            linkUrl={href("/podcasting-guide")}
             description="マイクやオーディオインターフェースなど収録環境や、編集環境についてのまとめです。"
           />
         </div>

--- a/app/routes/sp/show.tsx
+++ b/app/routes/sp/show.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/show";
 
-import { Link, useLoaderData } from "react-router-dom";
+import { Link, href, useLoaderData } from "react-router";
 
 import { LabelBadge } from "@/components/LabelBadge";
 import { proseStyles, Paragraph } from "@/components/Paragraph";
@@ -106,7 +106,7 @@ function SpShow() {
             </Link>{" "}
             や<Link to="https://twitter.com/diningfm">@diningfm</Link>{" "}
             へのリプライ、
-            <Link to="/letter">GoogleForm</Link>
+            <Link to={href("/letter")}>GoogleForm</Link>
             でのお便りなどからお待ちしています📮
           </Paragraph>
         </div>
@@ -120,7 +120,7 @@ function SpShow() {
           ))}
         </div>
         <div className="flex justify-center mt-6">
-          <LinkButton to="/episodes/page/1">
+          <LinkButton to={href("/episodes/page/:page", { page: "1" })}>
             すべてのエピソードを見る
           </LinkButton>
         </div>


### PR DESCRIPTION
Replace hardcoded path strings with href() from "react-router" across all route and component files. Also unify imports from "react-router" instead of "react-router-dom".

ref: https://api.reactrouter.com/v7/functions/react-router.href.html